### PR TITLE
Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM perl
+
+COPY --from=johannesfritsch/tttool /usr/local/bin/tttool /usr/local/bin
+
+RUN apt-get update && apt-get install -y \
+    libc6-dev \
+    libxml2-dev \
+    zlib1g-dev 
+
+RUN cpan -T -i \
+    EV \
+    AnyEvent::HTTPD \
+    Path::Class \
+    Cwd \
+    File::Basename \
+    File::Find \
+    List::MoreUtils \
+    PAR \
+    Encode \
+    Text::Template \
+    JSON::XS \
+    URI::Escape \
+    Getopt::Long \
+    Perl::Version \
+    DBI \
+    DBIx::MultiStatementDo \
+    Log::Message::Simple \
+    Music::Tag::MP3 \
+    Music::Tag::OGG \
+    Music::Tag::MusicBrainz \
+    Music::Tag::Auto \
+    MP3::Tag \
+    Image::Info \
+    WebService::MusicBrainz::Artist \
+    Locale::Country \
+    Locale::Codes
+    
+WORKDIR /ttmp32gme
+COPY . .
+RUN mkdir config
+ENV APPDATA=/var/lib/
+RUN mkdir ${APPDATA}/ttmp32gme
+WORKDIR /ttmp32gme/src
+
+EXPOSE 8080
+
+CMD [ "perl", "ttmp32gme.pl", "--debug", "--host=0.0.0.0", "--port=8080", "--configdir=/ttmp32gme/config" ]
+# HEALTHCHECK --interval=5m --timeout=3s \
+  # CMD curl -f http://localhost:8080/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ RUN cpan -T -i \
     
 WORKDIR /ttmp32gme
 COPY . .
-RUN mkdir config
 ENV APPDATA=/var/lib/
-RUN mkdir ${APPDATA}/ttmp32gme
+RUN mkdir config ${APPDATA}/ttmp32gme /mnt/tiptoi
+RUN echo "/dev/disk/by-label/tiptoi /mnt/tiptoi vfat umask=0777,auto,flush 0 1" >> /etc/fstab
 WORKDIR /ttmp32gme/src
 
 EXPOSE 8080

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #/bin/bash
-ttmp32gmeStorage=~/.ttmp32gme
+ttmp32gmeStorage=/var/lib/ttmp32gme
 mkdir -p ${ttmp32gmeStorage}
 
 docker run -d \

--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ docker run -d \
     --device /dev/disk/by-label/tiptoi:/dev/disk/by-label/tiptoi \
     --security-opt apparmor:unconfined --cap-add SYS_ADMIN \
     --name ttmp32gme \
-    fabian/ttmp32gme:latest
+    fabmay/ttmp32gme:latest

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+ttmp32gmeStorage=~/.ttmp32gme
+mkdir -p ${ttmp32gmeStorage}
+
+docker run -d \
+    --publish 8080:8080 \
+    --volume ${ttmp32gmeStorage}:/var/lib/ttmp32gme \
+    --device /dev/disk/by-label/tiptoi:/dev/disk/by-label/tiptoi \
+    --security-opt apparmor:unconfined --cap-add SYS_ADMIN \
+    --name ttmp32gme \
+    fabian/ttmp32gme:latest

--- a/src/TTMp32Gme/Build/FileHandler.pm
+++ b/src/TTMp32Gme/Build/FileHandler.pm
@@ -222,6 +222,12 @@ sub get_tiptoi_dir {
 				return $d;
 			}
 		}
+	} else {
+		my $mountPoint = "/mnt/tiptoi";
+		system("mountpoint", "-q", "$mountPoint") == 0 || system("mount", "$mountPoint") == 0;
+		if ( -f "$mountPoint/tiptoi.ico" ) {
+		    return $mountPoint;
+		}
 	}
 	return 0;
 }

--- a/src/ttmp32gme.pl
+++ b/src/ttmp32gme.pl
@@ -43,6 +43,7 @@ $debug=0;
 # Encapsulate configuration code
 {
 	my $port;
+	my $host;
 	my $directory  = "";
 	my $configdir  = "";
 	my $configfile = "";
@@ -51,9 +52,10 @@ $debug=0;
 	my $version = Perl::Version->new("0.2.2");
 
 # Command line startup options
-# Usage: ttmp32gme(.exe) [-d|--directory=dir] [-p|--port=port#] [-c|--configdir=dir] [-v|--version]
+# Usage: ttmp32gme(.exe) [-d|--directory=dir] [-h|--host=host#] [-p|--port=port#] [-c|--configdir=dir] [-v|--version]
 	GetOptions(
 		"port=i" => \$port,    # Port for the local web server to run on
+		"host=s" => \$host,    # Host for the local web server to run on
 		"directory=s" =>
 			\$directory,    # Directory to change to after starting (for dev mostly)
 		"configdir=s" => \$configdir,    # Where your config files are located
@@ -95,6 +97,11 @@ $debug=0;
 	# Port setting from the command line is temporary
 	if ($port) {
 		$config{'port'} = $port;
+	}
+
+	# Host setting from the command line is temporary
+	if ($host) {
+		$config{'host'} = $host;
 	}
 }
 
@@ -168,7 +175,7 @@ my $httpd =
 	AnyEvent::HTTPD->new( host => $config{'host'}, port => $config{'port'} );
 msg(
 	"Server running on port: $config{'port'}\n"
-		. "Open http://127.0.0.1:$config{'port'}/ in your favorite web browser to continue.\n",
+		. "Open http://$config{'host'}:$config{'port'}/ in your favorite web browser to continue.\n",
 	1
 );
 


### PR DESCRIPTION
This branch allows to run ttmp32gme on a linux host as docker container. It uses the tttool binary from this image: https://hub.docker.com/r/johannesfritsch/tttool
In order to run the container plug in the tiptoi (`/dev/disk/by-label/tiptoi` must be available) and start `run.sh`