### PR TITLE
fix Dockerfile: default command terminating upon start

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -7,6 +7,6 @@ RUN mkdir config ${APPDATA}/ttmp32gme /mnt/tiptoi
 
 EXPOSE 8080
 
-CMD perl ttmp32gme.pl --debug --host=0.0.0.0 --port=8080 --configdir=/ttmp32gme/config
+CMD perl ttmp32gme.pl --debug=2 --host=0.0.0.0 --port=8080 --configdir=/ttmp32gme/config
 # HEALTHCHECK --interval=5m --timeout=3s \
   # CMD curl -f http://localhost:8080/ || exit 1


### PR DESCRIPTION
Since https://github.com/thawn/ttmp32gme/commit/7c02b004be473b29ca3909513fc67752162541af the --debug option requires an integer level. 
The default command in the image[1] therefore immediately terminates upon start with
    Value "--host=0.0.0.0" invalid for option debug (number expected)

[1]  I'm trying the one from hub.docker.io:
```json
{
          "Id": "77ec581562e224958c4cc44daecbe3b883386df97f0eef9a04498e904cd6a5f0",
          "Digest": "sha256:6a54f9d18e651ea6b561f30b068023359ef76bc77c12d84db689aadbf7cbb568",
          "RepoTags": [
               "docker.io/thawn/ttmp32gme:latest"
          ],