### PR TITLE
fix docker startup again in 2025

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -7,6 +7,6 @@ RUN mkdir config ${APPDATA}/ttmp32gme /mnt/tiptoi
 
 EXPOSE 8080
 
-CMD perl ttmp32gme.pl --debug=2 --host=0.0.0.0 --port=8080 --configdir=/ttmp32gme/config
+CMD perl ttmp32gme.pl --port=8080 --host=0.0.0.0 --debug=2 --configdir=/ttmp32gme/config
 # HEALTHCHECK --interval=5m --timeout=3s \
   # CMD curl -f http://localhost:8080/ || exit 1


### PR DESCRIPTION
>  $ podman run -it --replace --publish 8080:8080 --volume ~/.ttmp32gme:/var/lib/ttmp32gme --name ttmp32gme thawn/ttmp32gme:latest 

> **Value "--host=0.0.0.0" invalid for option debug (number expected)**

> Updating config...
Update successful.
[MSG] Server running on port: 8080
Open http://127.0.0.1:8080/ in your favorite web browser to continue.
[MSG] using tttool: /usr/local/bin/tttool

In the latest iteration, ttmp32gme does not run properly from docker any more. The error message doesn't look so bad, but it prevents the web interface from coming up. The website at http://127.0.0.1:8080/ does not connect at all.
I managed to fix the original error by swapping the command line arguments into the expected order. After this, the  service comes up as expected.

The example run is podman, but I think I saw this problem with Docker on windows a well.

Please consider integrating this fix and putting it on the official image.