### PR TITLE
Fix permission denied error when printing second album

### DIFF
--- a/src/TTMp32Gme/TttoolHandler.pm
+++ b/src/TTMp32Gme/TttoolHandler.pm
@@ -271,9 +271,9 @@ sub create_oids {
 	foreach my $oid ( @{$oids} ) {
 		my $oid_file = file( $target_path, "$oid-$size-$tt_params->{'dpi'}-$tt_params->{'pixel-size'}.png" );
 		if ( !-f $oid_file ) {
-			run_tttool( $tt_command . $oid, "", $dbh )
+			run_tttool( $tt_command . $oid, $target_path, $dbh )
 				or die "Could not create oid file: $!";
-			file("oid-$oid.png")->move_to($oid_file);
+			file($target_path, "oid-$oid.png")->move_to($oid_file);
 		}
 		push( @files, $oid_file );
 	}


### PR DESCRIPTION
This resolves https://github.com/thawn/ttmp32gme/issues/61. The reason for that error is that `tttool` is run in the current working directory when creating the oid, which in Docker is `/ttmp32gme` - a read-only filesystem.

The PR changes this to the oid cache directory, which is part of the library data and has to be writable.